### PR TITLE
error.php file protections don't work properly with PHP's CGI mode

### DIFF
--- a/libraries/joomla/error/log.php
+++ b/libraries/joomla/error/log.php
@@ -180,6 +180,9 @@ class JLog extends JObject
 			if (!JFolder :: create(dirname($this->_path))) {
 				return false;
 			}
+			// Start with empty comment line to prevent file content from being shown due to a PHP CGI bug -
+			// see http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27641
+			$header[] = "#";
 			$header[] = "#<?php die('Direct Access To Log Files Not Permitted'); ?>";
 			$header[] = "#Version: 1.0";
 			$header[] = "#Date: " . $date;


### PR DESCRIPTION
See http://joomlacode.org/gf/project/joomla/tracker/?action=TrackerItemEdit&tracker_item_id=27641 for information.

This fix will affect a newly created /logs/error.php file. With an already existing file: either manually add such an empty comment line to it, or delete the file for it to be re-created with such a line.
