### PR TITLE
Avoid error messages and occasional core dumps

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -339,8 +339,10 @@ class JSession extends JObject
 			$error = null;
 			return $error;
 		}
-
-		return $this->data->getValue($namespace . '.' . $name, $default);
+		
+		$ret = $this->data->getValue($namespace . '.' . $name, $default);
+		
+		return $ret;
 	}
 
 	/**


### PR DESCRIPTION
After patching our ancient joomla 1.5 installations with the current session hardening fix, we noticed the following error messages in the log files occur:

Notice: Only variable references should be returned by reference in /srv/www/htdocs/sheep/libraries/joomla/session/session.php on line 343

On some instances running via apache/php/fcgi (apache 2.4, php 5.4.16, mod_fcgid) we encounter occasional core dumps.

The change avoids the error message by assigning the result of the method call first to a variable and returning that variable.

As a result the error messages are gone and the occasional core dumps did not occur anymore
