### PR TITLE
CVE-2017-7985

### DIFF
--- a/libraries/joomla/filter/filterinput.php
+++ b/libraries/joomla/filter/filterinput.php
@@ -223,8 +223,10 @@ class JFilterInput extends JObject
 	 */
 	function checkAttribute($attrSubSet)
 	{
+		$quoteStyle = version_compare(PHP_VERSION, '5.4', '>=') ? ENT_QUOTES | ENT_HTML401 : ENT_QUOTES;
+
 		$attrSubSet[0] = strtolower($attrSubSet[0]);
-		$attrSubSet[1] = strtolower($attrSubSet[1]);
+		$attrSubSet[1] = html_entity_decode(strtolower($attrSubSet[1]), $quoteStyle, 'UTF-8');
 		return (((strpos($attrSubSet[1], 'expression') !== false) && ($attrSubSet[0]) == 'style') || (strpos($attrSubSet[1], 'javascript:') !== false) || (strpos($attrSubSet[1], 'behaviour:') !== false) || (strpos($attrSubSet[1], 'vbscript:') !== false) || (strpos($attrSubSet[1], 'mocha:') !== false) || (strpos($attrSubSet[1], 'livescript:') !== false));
 	}
 


### PR DESCRIPTION
Taking over checkAttribute hardening from https://github.com/joomla-framework/filter/commit/11a8697e3419bbd68fe2be9a8b406b471436754e (and https://github.com/joomla/joomla-cms/commit/011a6f5cc34bcc67338db2d24828fdff5940cbb6#diff-91db57e9ce12007fbe6de1a4ab30d4c1R534).

This is possibly related to CVE-2017-7985, https://developer.joomla.org/security-centre/685-20170403-core-xss-vulnerability.html , low severity.